### PR TITLE
fix: Gracefully close zmq Context and Socket at progress server close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Fix: Gracefully close zmq Context and Socket at progress server close
 - Add global stage aliases to provide drop-in replacement for existing stages
 - Add *externals* support
 

--- a/src/synpp/progress.py
+++ b/src/synpp/progress.py
@@ -66,9 +66,9 @@ class ProgressTracker:
 class ProgressServer(threading.Thread):
     def __init__(self, tracker):
         threading.Thread.__init__(self)
-        context = zmq.Context()
+        self.context = zmq.Context()
 
-        self.socket = context.socket(zmq.PULL)
+        self.socket = self.context.socket(zmq.PULL)
         self.port = self.socket.bind_to_random_port("tcp://*")
         self.running = True
 
@@ -90,6 +90,10 @@ class ProgressServer(threading.Thread):
 
     def stop(self):
         self.running = False
+        time.sleep(0.001)
+
+        self.socket.close()
+        self.context.term()
 
 class ProgressClient:
     def __init__(self, port):


### PR DESCRIPTION
When using `progress`, I sometimes have this warning:
`ResourceWarning: Unclosed socket <zmq.Socket(zmq.PULL)`

I suggest gracefully closing the socket and the context of ZMQ at the close of the progress context.