### PR TITLE
Add maxtasksperchild for parallel execution

### DIFF
--- a/src/synpp/parallel.py
+++ b/src/synpp/parallel.py
@@ -47,13 +47,14 @@ class wrap_callable:
             yield (self.callable, element)
 
 class ParallelMasterContext:
-    def __init__(self, data, config, processes, progress_context):
+    def __init__(self, data, config, processes, progress_context, maxtasksperchild):
         if processes is None: processes = mp.cpu_count()
 
         self.processes = processes
         self.config = config
         self.data = data
         self.pool = None
+        self.maxtasksperchild = maxtasksperchild
 
         self.progress_context = progress_context
 
@@ -69,7 +70,8 @@ class ParallelMasterContext:
         self.pool = mp.Pool(
             processes = self.processes,
             initializer = pipeline_initializer,
-            initargs = (self.data, self.config, progress_port)
+            initargs = (self.data, self.config, progress_port),
+            maxtasksperchild = self.maxtasksperchild
         )
 
         return self

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -326,7 +326,7 @@ class ExecuteContext(Context):
 
         return self.dependency_info[dependency][name]
 
-    def parallel(self, data = {}, processes = None, serialize = False):
+    def parallel(self, data = {}, processes = None, serialize = False, maxtasksperchild = None):
         config = self.required_config
 
         if processes is None and "processes" in self.pipeline_config:
@@ -338,7 +338,7 @@ class ExecuteContext(Context):
             # for profiling the code.
             return ParalelMockMasterContext(data, config, self.progress_context)
         else:
-            return ParallelMasterContext(data, config, processes, self.progress_context)
+            return ParallelMasterContext(data, config, processes, self.progress_context, maxtasksperchild)
 
     def progress(self, iterable = None, label = None, total = None, minimum_interval = 1.0):
         if minimum_interval is None and "progress_interval" in self.pipeline_config:

--- a/src/synpp/progress.py
+++ b/src/synpp/progress.py
@@ -97,13 +97,17 @@ class ProgressServer(threading.Thread):
 
 class ProgressClient:
     def __init__(self, port):
-        context = zmq.Context()
+        self.context = zmq.Context()
 
-        self.socket = context.socket(zmq.PUSH)
+        self.socket = self.context.socket(zmq.PUSH)
         self.socket.connect("tcp://localhost:%d" % port)
 
     def update(self, amount = 1):
         self.socket.send_string(json.dumps(dict(amount = amount)))
+
+    def close(self):
+        self.socket.close()
+        self.context.term()
 
 class ProgressContext:
     def __init__(self, iterable = None, total = None, label = None, logger = logging.getLogger("synpp"), minimum_interval = 0):

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -10,22 +10,22 @@ def test_parallel():
 
     arguments = [1000000, 2000000, 3000000]
 
-    with ParallelMasterContext(data, config, 3, None) as parallel:
+    with ParallelMasterContext(data, config, 3, None, None) as parallel:
         result = parallel.map(sum_up, arguments)
 
     assert result == [1001245, 2001245, 3001245]
 
-    with ParallelMasterContext(data, config, 3, None) as parallel:
+    with ParallelMasterContext(data, config, 3, None, None) as parallel:
         result = parallel.map_async(sum_up, arguments).get()
 
     assert result == [1001245, 2001245, 3001245]
 
-    with ParallelMasterContext(data, config, 3, None) as parallel:
+    with ParallelMasterContext(data, config, 3, None, None) as parallel:
         result = list(parallel.imap(sum_up, arguments))
 
     assert result == [1001245, 2001245, 3001245]
 
-    with ParallelMasterContext(data, config, 3, None) as parallel:
+    with ParallelMasterContext(data, config, 3, None, None) as parallel:
         result = list(parallel.imap_unordered(sum_up, arguments))
 
     assert 1001245 in result


### PR DESCRIPTION
The `maxtasksperchild` parameter given to Pool construction permits to kill and relaunch the worker to free memory. During long runs, this also avoids memory "leaks."

I suggest adding this parameter to pool construction through synpp.