### PR TITLE
fix: Adapt configuration comparisons when using nested parameters

### DIFF
--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -162,7 +162,7 @@ def get_config_path(name, config):
 
 def has_config_value(name, config):
     splitted_req = name.split(".")
-    for key in config:
+    for key in flatten(config):
         found = True
         spltted_key = key.split(".")
         for idx in range(len(splitted_req)):
@@ -175,13 +175,14 @@ def has_config_value(name, config):
 
 
 def get_config_value(name, config):
-    if name in config:
-        return config[name]
+    flat = flatten(config)
+    if name in flat:
+        return flat[name]
 
     splitted_req = name.split(".")
     values = []
     keys = []
-    for key in config:
+    for key in flat:
         found = True
         splitted_key = key.split(".")
         for idx in range(len(splitted_req)):
@@ -190,7 +191,7 @@ def get_config_value(name, config):
                 break
         if found:
             keys.append(".".join(splitted_key[len(splitted_req):]))
-            values.append(config[key])
+            values.append(flat[key])
     return unflatten(dict(zip(keys, values)))
 
 def configure_stage(instance, context, config):

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -309,7 +309,7 @@ class ValidateContext(Context):
 
 
 class ExecuteContext(Context):
-    def __init__(self, required_config, required_stages, aliases, working_directory, dependencies, cache_path, pipeline_config, logger, cache, dependency_info, dependency_cache):
+    def __init__(self, required_config, required_stages, aliases, working_directory, dependencies, cache_path, pipeline_config, logger, cache, dependency_info):
         self.required_config = required_config
         self.working_directory = working_directory
         self.dependencies = dependencies
@@ -317,7 +317,7 @@ class ExecuteContext(Context):
         self.cache_path = cache_path
         self.logger = logger
         self.stage_info = {}
-        self.dependency_cache = dependency_cache
+        self.dependency_cache = {}
         self.cache = cache
         self.dependency_info = dependency_info
         self.aliases = aliases

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -38,7 +38,7 @@ def rmtree(path):
 def flatten(d, parent_key='', sep='.'):
     items = []
     for k, v in d.items():
-        new_key = parent_key + sep + k if parent_key else k
+        new_key = str(parent_key) + sep + str(k) if parent_key else str(k)
         if isinstance(v, MutableMapping):
             items.extend(flatten(v, new_key, sep=sep).items())
         else:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -144,3 +144,25 @@ def test_is_config_requested():
                       {'descriptor': "tests.fixtures.devalidation.A2"}])
     assert res1[0] == 10
     assert res2[0] == 5
+
+
+class ComplexStageWithResult:
+    def configure(self, context):
+        context.config("option")
+        context.config("option.sub")
+
+    def execute(self, context):
+        return context.config("option")["sub"], context.config("option.sub")
+
+
+class ComplexStageWithResultMaster:
+    def configure(self, context):
+        context.stage(ComplexStageWithResult, {"option": {"sub": 201}}, alias=0)
+
+    def execute(self, context):
+        return context.stage(0)
+
+
+def test_nested_config():
+    res = synpp.run([{'descriptor': ComplexStageWithResultMaster, 'config': {}}])
+    assert res[0] == (201, 201)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -148,21 +148,20 @@ def test_is_config_requested():
 
 class ComplexStageWithResult:
     def configure(self, context):
-        context.config("option")
         context.config("option.sub")
 
     def execute(self, context):
-        return context.config("option")["sub"], context.config("option.sub")
+        return context.config("option")["sub"]
 
 
 class ComplexStageWithResultMaster:
     def configure(self, context):
-        context.stage(ComplexStageWithResult, {"option": {"sub": 201}}, alias=0)
+        context.stage(ComplexStageWithResult, alias=0)
 
     def execute(self, context):
         return context.stage(0)
 
 
 def test_nested_config():
-    res = synpp.run([{'descriptor': ComplexStageWithResultMaster, 'config': {}}])
-    assert res[0] == (201, 201)
+    res = synpp.run([{'descriptor': ComplexStageWithResultMaster, 'config': {"option.sub": 3}}])
+    assert res[0] == 3


### PR DESCRIPTION
Hello,
I extensively use nested parameters in my Yaml configuration file. However, when I launch any stage with "explicit" nested parameters from other stages, the stage processing needs to handle the configuration dictionary correctly. Indeed, it uses the keys of the first level of the dictionary to detect the "explicit" parameters, so it misses all the child parameters. I fixed it by flattening the dictionary keys when updating configuration requirements.

Let me know if you find a better way to fix it.
Aina