### PR TITLE
Avoid monolithic state file

### DIFF
--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -737,8 +737,6 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
     logger.info("Devalidating %d stages:" % len(stale_hashes))
     for hash in stale_hashes: logger.info("- %s" % hash)
 
-    logger.info("Successfully reset meta data")
-
     # 6) Execute stages
     results = [None] * len(definitions)
     cache = {}

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -693,7 +693,7 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
 
     # 4.8) Manually devalidate stages
     for hash in sorted_hashes:
-        if hash not in cache_available or current_validation_tokens[hash] not in cache_available[hash]:
+        if hash in cache_available and current_validation_tokens[hash] not in cache_available[hash]:
             stale_hashes.add(hash)
 
     # 4.1) Devalidate if they are required (optional, otherwise will reload from cache)
@@ -715,7 +715,6 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
                     if dependency_ctime > ctime:
                         stale_hashes.add(hash)
                         break
-
 
     # 4.9) Devalidate descendants of devalidated stages
     for hash in set(stale_hashes):

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -640,20 +640,20 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
 
     sorted_hashes = list(nx.topological_sort(graph))
 
-    # Compute cache prefixes by appending source code digest
-    source_codes = {}
+    # Concatenate source digest of dependencies
+    source_digests = {}
     for hash in sorted_hashes:
-        source_codes[hash] = ""
+        source_digests[hash] = ""
         for dependency_hash in nx.ancestors(graph, hash):
-            source_codes[hash] += registry[dependency_hash]["wrapper"].module_hash
-        source_codes[hash] += registry[hash]["wrapper"].module_hash
+            source_digests[hash] += registry[dependency_hash]["wrapper"].module_hash
+        source_digests[hash] += registry[hash]["wrapper"].module_hash
 
     # Check where cache is available
     cache_available = {}
 
     if not working_directory is None:
         for hash in sorted_hashes:
-            prefix = get_cache_prefix(hash, source_codes[hash])
+            prefix = get_cache_prefix(hash, source_digests[hash])
             prefixed = [filename[:-2] for filename in os.listdir(working_directory) if filename.startswith(prefix) and filename.endswith(".p")]
 
             if prefixed:
@@ -687,7 +687,7 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
     }
 
     # Cache mapper between stage id and cache id.
-    cache_ids = {stage_id: get_cache_prefix(stage_id, source_codes[stage_id]) + "__" + str(current_validation_tokens[stage_id]) for stage_id in sorted_hashes}
+    cache_ids = {stage_id: get_cache_prefix(stage_id, source_digests[stage_id]) + "__" + str(current_validation_tokens[stage_id]) for stage_id in sorted_hashes}
     file_cache_paths = {stage_id: get_cache_file_path(working_directory, cache_id) for stage_id, cache_id in cache_ids.items()}
     dir_cache_paths = {stage_id: get_cache_directory_path(working_directory, cache_id) for stage_id, cache_id in cache_ids.items()}
 

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -718,7 +718,7 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
             if not hash in stale_hashes:
                 ctime = os.stat(file_cache_paths[hash]).st_mtime_ns
                 for dependency_hash in nx.ancestors(graph, hash):
-                    if dependency_hash not in stale_hashes:
+                    if dependency_hash not in stale_hashes and dependency_hash in cache_available:
                         dependency_ctime = os.stat(file_cache_paths[dependency_hash]).st_mtime_ns
                         if dependency_ctime > ctime:
                             stale_hashes.add(hash)

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -711,10 +711,11 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
             if not hash in stale_hashes:
                 ctime = os.stat(file_cache_paths[hash]).st_mtime_ns
                 for dependency_hash in nx.ancestors(graph, hash):
-                    dependency_ctime = os.stat(file_cache_paths[dependency_hash]).st_mtime_ns
-                    if dependency_ctime > ctime:
-                        stale_hashes.add(hash)
-                        break
+                    if dependency_hash not in stale_hashes:
+                        dependency_ctime = os.stat(file_cache_paths[dependency_hash]).st_mtime_ns
+                        if dependency_ctime > ctime:
+                            stale_hashes.add(hash)
+                            break
 
     # 4.9) Devalidate descendants of devalidated stages
     for hash in set(stale_hashes):

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -221,11 +221,11 @@ def hash_name(name, config):
     else:
         return name
 
-def get_cache_directory_path(working_directory, hash):
-    return "%s/%s.cache" % (working_directory, hash)
+def get_cache_directory_path(working_directory, stage_hash):
+    return "%s/%s.cache" % (working_directory, stage_hash)
 
-def get_cache_file_path(working_directory, hash):
-    return "%s/%s.p" % (working_directory, hash)
+def get_cache_file_path(working_directory, stage_hash):
+    return "%s/%s.p" % (working_directory, stage_hash)
 
 class ConfiguredStage:
     def __init__(self, instance, config, configuration_context):

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -672,7 +672,6 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
                 ephemeral_counts[hash] += 1
 
     # 4) Devalidate stages
-    sorted_cached_hashes = sorted_hashes
     stale_hashes = set()
 
     # Get current validation tokens
@@ -682,14 +681,14 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
             registry[stage_id]["wrapper"].validate(
                 ValidateContext(registry[stage_id]["config"], get_cache_directory_path(working_directory, stage_id))
             )
-        ) for stage_id in sorted_cached_hashes
+        ) for stage_id in sorted_hashes
     }
 
     # Cache mapper between stage id and cache id.
-    cache_ids = {stage_id: get_cache_id(stage_id, source_codes[stage_id], current_validation_tokens[stage_id]) for stage_id in sorted_cached_hashes}
+    cache_ids = {stage_id: get_cache_id(stage_id, source_codes[stage_id], current_validation_tokens[stage_id]) for stage_id in sorted_hashes}
 
     # 4.8) Manually devalidate stages
-    for hash in sorted_cached_hashes:
+    for hash in sorted_hashes:
         if hash not in cache_available or current_validation_tokens[hash] not in cache_available[hash]:
             print(f"Devalidation {hash}: Manually devalidate")
             stale_hashes.add(hash)
@@ -700,14 +699,14 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
         stale_hashes.update(required_hashes)
 
     # 4.5) Devalidate if cache is not existant
-    for hash in sorted_cached_hashes:
+    for hash in sorted_hashes:
         if not hash in cache_available:
             print(f"Devalidation {hash}: No cache")
             stale_hashes.add(hash)
 
     # 4.6) Devalidate if parent has been updated
     if working_directory is not None:
-        for hash in sorted_cached_hashes:
+        for hash in sorted_hashes:
             if not hash in stale_hashes:
                 ctime = os.stat(get_cache_file_path(working_directory, cache_ids[hash])).st_mtime_ns
                 # print(f"Cached {stage_id}: {ctime}")

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -648,16 +648,14 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
         source_codes[hash] += registry[hash]["wrapper"].source_code
 
     # Check where cache is available
-    cache_available = set()
-    stored_validation_tokens = {}
+    cache_available = {}
 
     if not working_directory is None:
         for hash in sorted_hashes:
             prefix = get_cache_prefix(hash, source_codes[hash])
             prefixed = [filename[:-2] for filename in os.listdir(working_directory) if filename.startswith(prefix) and filename.endswith(".p")]
             if prefixed:
-                stored_validation_tokens[hash] = [filename.split("__")[-1] for filename in prefixed]
-                cache_available.add(hash)
+                cache_available[hash] = [filename.split("__")[-1] for filename in prefixed]
                 registry[hash]["ephemeral"] = False
 
     # Set up ephemeral stage counts
@@ -692,7 +690,7 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
 
     # 4.8) Manually devalidate stages
     for hash in sorted_cached_hashes:
-        if hash not in stored_validation_tokens or current_validation_tokens[hash] not in stored_validation_tokens[hash]:
+        if hash not in cache_available or current_validation_tokens[hash] not in cache_available[hash]:
             print(f"Devalidation {hash}: Manually devalidate")
             stale_hashes.add(hash)
 

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -644,7 +644,7 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
     source_digests = {}
     for hash in sorted_hashes:
         source_digests[hash] = ""
-        for dependency_hash in nx.ancestors(graph, hash):
+        for dependency_hash in sorted(nx.ancestors(graph, hash)):
             source_digests[hash] += registry[dependency_hash]["wrapper"].module_hash
         source_digests[hash] += registry[hash]["wrapper"].module_hash
 

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -221,6 +221,11 @@ def hash_name(name, config):
     else:
         return name
 
+def get_cache_directory_path(working_directory, hash):
+    return "%s/%s.cache" % (working_directory, hash)
+
+def get_cache_file_path(working_directory, hash):
+    return "%s/%s.p" % (working_directory, hash)
 
 class ConfiguredStage:
     def __init__(self, instance, config, configuration_context):

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -785,17 +785,6 @@ def run(definitions, config = {}, working_directory = None, flowchart_path = Non
             logger.info("Executing stage %s ..." % hash)
             stage = registry[hash]
 
-            # Load the dependencies, either from cache or from file
-            #stage_dependencies = []
-            #stage_dependency_info = {}
-
-            #if name in dependencies:
-            #    stage_dependencies = dependencies[name]
-            #
-            #    for parent in stage_dependencies:
-            #        stage_dependency_info[parent] = meta[parent]["info"]
-            #stage_dependencies =
-
             stage_dependency_info = {}
             for dependency_hash in stage["dependencies"]:
                 stage_dependency_info[dependency_hash] = meta[dependency_hash]["info"]

--- a/tests/fixtures/devalidation/E.py
+++ b/tests/fixtures/devalidation/E.py
@@ -1,0 +1,11 @@
+def configure(context):
+    context.stage("tests.fixtures.devalidation.D", config={"d": 10}, alias="d")
+    context.stage("tests.fixtures.devalidation.C")
+    context.stage("tests.fixtures.devalidation.E1")
+    context.stage("tests.fixtures.devalidation.E2")
+
+def execute(context):
+    context.stage("tests.fixtures.devalidation.E1")
+    context.stage("tests.fixtures.devalidation.E2")
+    context.stage("d")
+    return context.stage("tests.fixtures.devalidation.C")

--- a/tests/fixtures/devalidation/E1.py
+++ b/tests/fixtures/devalidation/E1.py
@@ -1,0 +1,5 @@
+def configure(context):
+    pass
+
+def execute(context):
+    return 20

--- a/tests/fixtures/devalidation/E2.py
+++ b/tests/fixtures/devalidation/E2.py
@@ -1,0 +1,5 @@
+def configure(context):
+    pass
+
+def execute(context):
+    return 40

--- a/tests/fixtures/ephemeral/E.py
+++ b/tests/fixtures/ephemeral/E.py
@@ -1,0 +1,5 @@
+def configure(context):
+    context.stage("tests.fixtures.ephemeral.D")
+
+def execute(context):
+    pass

--- a/tests/test_devalidate.py
+++ b/tests/test_devalidate.py
@@ -117,6 +117,39 @@ def test_devalidate_descendants(tmpdir):
     assert "tests.fixtures.devalidation.B__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
     assert "tests.fixtures.devalidation.C__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
 
+import os
+import sys
+def test_devalidation_stability(tmpdir):
+    temp_directory = tmpdir.mkdir("sub")
+    working_directory = os.path.join(temp_directory, "cache")
+    config_yml_path = os.path.join(temp_directory, "config.yml")
+    config_yml = f"""run:
+  - tests.fixtures.devalidation.E
+
+working_directory: {working_directory}
+
+config:
+  a: 1"""
+    
+    with open(config_yml_path, "w") as f:
+        f.write(config_yml)
+
+    os.system(f"python -m synpp {config_yml_path}")
+
+    result = synpp.run([{
+        "descriptor": "tests.fixtures.devalidation.E"
+    }], config = { "a": 1 }, working_directory = working_directory, verbose = True)
+
+    assert not "tests.fixtures.devalidation.A1__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
+    assert not "tests.fixtures.devalidation.A2" in result["stale"]
+    assert not "tests.fixtures.devalidation.B__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
+    assert not "tests.fixtures.devalidation.C__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
+    assert "tests.fixtures.devalidation.E__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
+    assert not "tests.fixtures.devalidation.E1" in result["stale"]
+    assert not "tests.fixtures.devalidation.E2" in result["stale"]
+    print("done")
+
+
 def test_devalidate_token(tmpdir):
     working_directory = tmpdir.mkdir("sub")
     path = "%s/test.fixture" % working_directory

--- a/tests/test_devalidate.py
+++ b/tests/test_devalidate.py
@@ -147,7 +147,6 @@ config:
     assert "tests.fixtures.devalidation.E__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
     assert not "tests.fixtures.devalidation.E1" in result["stale"]
     assert not "tests.fixtures.devalidation.E2" in result["stale"]
-    print("done")
 
 
 def test_devalidate_token(tmpdir):

--- a/tests/test_devalidate.py
+++ b/tests/test_devalidate.py
@@ -65,7 +65,6 @@ def test_devalidate_by_parent(tmpdir):
     assert "tests.fixtures.devalidation.C__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
 
     time.sleep(0.1)
-
     result = synpp.run([{
         "descriptor": "tests.fixtures.devalidation.C"
     }], config = { "a": 1 }, working_directory = working_directory, verbose = True)
@@ -76,7 +75,6 @@ def test_devalidate_by_parent(tmpdir):
     assert "tests.fixtures.devalidation.C__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
 
     time.sleep(0.1)
-
     result = synpp.run([{
         "descriptor": "tests.fixtures.devalidation.A2"
     }], config = { "a": 1 }, working_directory = working_directory, verbose = True)
@@ -87,7 +85,6 @@ def test_devalidate_by_parent(tmpdir):
     assert not "tests.fixtures.devalidation.C__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
 
     time.sleep(0.1)
-
     result = synpp.run([{
         "descriptor": "tests.fixtures.devalidation.C"
     }], config = { "a": 1 }, working_directory = working_directory, verbose = True)

--- a/tests/test_devalidate.py
+++ b/tests/test_devalidate.py
@@ -1,5 +1,6 @@
 import synpp
 from pytest import raises
+import time
 
 def test_devalidate_by_config(tmpdir):
     working_directory = tmpdir.mkdir("sub")
@@ -63,6 +64,8 @@ def test_devalidate_by_parent(tmpdir):
     assert "tests.fixtures.devalidation.B__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
     assert "tests.fixtures.devalidation.C__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
 
+    time.sleep(0.1)
+
     result = synpp.run([{
         "descriptor": "tests.fixtures.devalidation.C"
     }], config = { "a": 1 }, working_directory = working_directory, verbose = True)
@@ -72,6 +75,8 @@ def test_devalidate_by_parent(tmpdir):
     assert not "tests.fixtures.devalidation.B__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
     assert "tests.fixtures.devalidation.C__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
 
+    time.sleep(0.1)
+
     result = synpp.run([{
         "descriptor": "tests.fixtures.devalidation.A2"
     }], config = { "a": 1 }, working_directory = working_directory, verbose = True)
@@ -80,6 +85,8 @@ def test_devalidate_by_parent(tmpdir):
     assert "tests.fixtures.devalidation.A2" in result["stale"]
     assert not "tests.fixtures.devalidation.B__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
     assert not "tests.fixtures.devalidation.C__42b7b4f2921788ea14dac5566e6f06d0" in result["stale"]
+
+    time.sleep(0.1)
 
     result = synpp.run([{
         "descriptor": "tests.fixtures.devalidation.C"

--- a/tests/test_ephemeral.py
+++ b/tests/test_ephemeral.py
@@ -85,3 +85,24 @@ def test_ephemeral_BD(tmpdir):
     assert not "tests.fixtures.ephemeral.B" in result["stale"]
     assert "tests.fixtures.ephemeral.C" in result["stale"]
     assert "tests.fixtures.ephemeral.D" in result["stale"]
+
+def test_ephemeral_E(tmpdir):
+    working_directory = tmpdir.mkdir("cache")
+
+    result = synpp.run([
+        { "descriptor": "tests.fixtures.ephemeral.E" },
+    ], working_directory = working_directory, verbose = True)
+
+    assert "tests.fixtures.ephemeral.A" in result["stale"]
+    assert "tests.fixtures.ephemeral.C" in result["stale"]
+    assert "tests.fixtures.ephemeral.D" in result["stale"]
+    assert "tests.fixtures.ephemeral.E" in result["stale"]
+
+    result = synpp.run([
+        { "descriptor": "tests.fixtures.ephemeral.E" },
+    ], working_directory = working_directory, verbose = True)
+
+    assert not "tests.fixtures.ephemeral.A" in result["stale"]
+    assert not "tests.fixtures.ephemeral.C" in result["stale"]
+    assert not "tests.fixtures.ephemeral.D" in result["stale"]
+    assert "tests.fixtures.ephemeral.E" in result["stale"]


### PR DESCRIPTION
In line with https://github.com/eqasim-org/synpp/issues/45, I refactored some things to make the whole framework run without the pipeline.json file. It passes all the tests but needs some review and real-world tests.

There is still no management of several concurrent pipelines that share the same stages. The idea is not to compute two times the same stage, even if pipelines are launched simultaneously.