### PR TITLE
feat: volatile config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+venv
 env
 build
 dist

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ no default value is given for an option in `configure` and in case that no
 specific value is passed to the stage, a global configuration that is specific
 to the pipeline will be used to look up the value.
 
+Note that the call to `context.config` can have a default value as the second argument, and you can set `volatile = True` which means that the stage will not be reevaluated if this config value changes. Such a behavior is useful if you are rather changing the number of cores or the available memory, but don't want to rerun the parts of the code that already passed with the given values.
+
 ### Execution
 
 The requested configuration values and stages are afterwards available

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -213,10 +213,10 @@ def configure_name(name, config):
     return "%s(%s)" % (name, ",".join(values))
 
 
-def hash_name(name, config):
+def hash_name(name, config, volatile):
     if len(config) > 0:
         hash = hashlib.md5()
-        hash.update(json.dumps(config, sort_keys = True).encode("utf-8"))
+        hash.update(json.dumps({ k: v for k, v in config.items() if not k in volatile }, sort_keys = True).encode("utf-8"))
         return "%s__%s" % (name, hash.hexdigest())
     else:
         return name
@@ -229,7 +229,7 @@ class ConfiguredStage:
         self.configuration_context = configuration_context
 
         self.configured_name = configure_name(instance.name, configuration_context.required_config)
-        self.hashed_name = hash_name(instance.name, configuration_context.required_config)
+        self.hashed_name = hash_name(instance.name, configuration_context.required_config, configuration_context.volatile_config)
 
     def configure(self, context):
         if hasattr(self.instance, "configure"):
@@ -252,6 +252,7 @@ class ConfigurationContext(Context):
         self.config_requested_stages = [resolve_stage(d, externals, global_aliases).instance for d in config_definitions]
 
         self.required_config = {}
+        self.volatile_config = set()
 
         self.required_stages = []
         self.aliases = {}
@@ -261,7 +262,7 @@ class ConfigurationContext(Context):
         self.externals = externals
         self.global_aliases = global_aliases
 
-    def config(self, option, default = NoDefaultValue()):
+    def config(self, option, default = NoDefaultValue(), volatile = False):
         if has_config_value(option, self.base_config):
             self.required_config[option] = get_config_value(option, self.base_config)
         elif not isinstance(default, NoDefaultValue):
@@ -273,6 +274,9 @@ class ConfigurationContext(Context):
         if not option in self.required_config:
             raise PipelineError("Config option is not available: %s" % option)
 
+        if volatile:
+            self.volatile_config.add(option)
+        
         return self.required_config[option]
 
     def stage(self, descriptor, config = {}, alias = None, ephemeral = False):
@@ -432,12 +436,13 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
             "wrapper": wrapper,
             "config": copy.copy(required_config),
             "required_config": copy.copy(required_config),
+            "volatile_config": context.volatile_config,
             "required_stages": context.required_stages,
             "aliases": context.aliases
         })
 
         # Check for cycles
-        cycle_hash = hash_name(definition["wrapper"].name, definition["config"])
+        cycle_hash = hash_name(definition["wrapper"].name, definition["config"], definition["volatile_config"])
 
         if "cycle_hashes" in definition and cycle_hash in definition["cycle_hashes"]:
             print(definition["cycle_hashes"])
@@ -531,7 +536,7 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
     required_hashes = {}
 
     for stage in stages:
-        stage["hash"] = hash_name(stage["wrapper"].name, stage["config"])
+        stage["hash"] = hash_name(stage["wrapper"].name, stage["config"], stage["volatile_config"])
 
         if "required-index" in stage:
             index = stage["required-index"]

--- a/tests/fixtures/devalidation/volatile_a.py
+++ b/tests/fixtures/devalidation/volatile_a.py
@@ -1,0 +1,6 @@
+def configure(context):
+    context.config("a", volatile = True, default = 100)
+    context.config("u.v.w", volatile = True, default = 0)
+
+def execute(context):
+    return context.config("a") + context.config("u.v.w")

--- a/tests/fixtures/devalidation/volatile_b.py
+++ b/tests/fixtures/devalidation/volatile_b.py
@@ -1,0 +1,5 @@
+def configure(context):
+    context.stage("tests.fixtures.devalidation.volatile_a")
+
+def execute(context):
+    return context.stage("tests.fixtures.devalidation.volatile_a")

--- a/tests/test_devalidate.py
+++ b/tests/test_devalidate.py
@@ -224,3 +224,44 @@ def test_devalidate_by_changed_file(tmpdir):
 
     assert name_a in result["stale"]
     assert name_b in result["stale"]
+
+def test_volatile_config(tmpdir):
+    working_directory = tmpdir.mkdir("sub")
+
+    result = synpp.run([{
+        "descriptor": "tests.fixtures.devalidation.volatile_b"
+    }], config = { "a": 123 }, working_directory = working_directory, verbose = True)
+
+    assert len(result["stale"]) == 2
+    assert "tests.fixtures.devalidation.volatile_a__99914b932bd37a50b983c5e7c90ae93b" in result["stale"]
+    assert "tests.fixtures.devalidation.volatile_b__c007f8fea8b5cc845e93f593a7ae9cd6" in result["stale"]
+    assert result["results"][0] == 123
+
+    result = synpp.run([{
+        "descriptor": "tests.fixtures.devalidation.volatile_b"
+    }], config = { "a": 456 }, working_directory = working_directory, verbose = True)
+
+    assert len(result["stale"]) == 1
+    assert "tests.fixtures.devalidation.volatile_b__c007f8fea8b5cc845e93f593a7ae9cd6" not in result["stale"]
+    assert result["results"][0] == 123
+
+
+def test_volatile_config_hierarchical(tmpdir):
+    working_directory = tmpdir.mkdir("sub")
+
+    result = synpp.run([{
+        "descriptor": "tests.fixtures.devalidation.volatile_b"
+    }], config = { "u": { "v": { "w": 44 } } }, working_directory = working_directory, verbose = True)
+
+    assert len(result["stale"]) == 2
+    assert "tests.fixtures.devalidation.volatile_a__99914b932bd37a50b983c5e7c90ae93b" in result["stale"]
+    assert "tests.fixtures.devalidation.volatile_b__aa771c9d4d6ba16fdcb37988e55eab98" in result["stale"]
+    assert result["results"][0] == 144
+
+    result = synpp.run([{
+        "descriptor": "tests.fixtures.devalidation.volatile_b"
+    }], config = { "u": { "v": { "w": 55 } } }, working_directory = working_directory, verbose = True)
+
+    assert len(result["stale"]) == 1
+    assert "tests.fixtures.devalidation.volatile_b__aa771c9d4d6ba16fdcb37988e55eab98" not in result["stale"]
+    assert result["results"][0] == 144


### PR DESCRIPTION
This PR introduces the `volatile = True` option when obtaining config values in the `configure` step using `context.config(...)`. Config options that are marked as *volatile* do not cause a reevaluation of the stage if the value changes. This is especially useful if you pass the number of cores or memory restrictions to the stages and you might need to increase this value step by step. In that case you don't want stages that have already ran successfully to run again.