### PR TITLE
fix: resolution speedup

### DIFF
--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -406,7 +406,7 @@ class ExecuteContext(Context):
 
 def process_stages(definitions, global_config, externals={}, aliases={}):
     pending = copy.copy(definitions)
-    stages = []
+    hashed_stages = {}
 
     for index, stage in enumerate(pending):
         stage["required-index"] = index
@@ -445,13 +445,18 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
         cycle_hash = hash_name(definition["wrapper"].name, definition["config"], definition["volatile_config"])
 
         if "cycle_hashes" in definition and cycle_hash in definition["cycle_hashes"]:
-            print(definition["cycle_hashes"])
-            print(cycle_hash)
             raise PipelineError("Found cycle in dependencies: %s" % definition["wrapper"].name)
 
-        # Everything fine, add it
-        stages.append(definition)
-        stage_index = len(stages) - 1
+        # Identification
+        config.update(required_config)
+        identification_hash = hash_name(definition["wrapper"].name, config, {})
+
+        while identification_hash in hashed_stages:
+            identification_hash = "{}+".format(identification_hash)
+
+        # Everything fine, add 
+        hashed_stages[identification_hash] = definition
+        definition["identification-hash"] = identification_hash
 
         # Process dependencies
         for position, upstream in enumerate(context.required_stages):
@@ -466,7 +471,7 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
             upstream = copy.copy(upstream)
             upstream.update({
                 "config": upstream_config,
-                "downstream-index": stage_index,
+                "downstream-hash": identification_hash,
                 "downstream-position": position,
                 "downstream-length": len(context.required_stages),
                 "downstream-passed-parameters": passed_parameters,
@@ -476,43 +481,43 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
             pending.append(upstream)
 
     # Now go backwards in the tree to find intermediate config requirements and set up dependencies
-    downstream_indices = set([
-        stage["downstream-index"]
-        for stage in stages if "downstream-index" in stage
+    downstream_hashes = set([
+        stage["downstream-hash"]
+        for stage in hashed_stages.values() if "downstream-hash" in stage
     ])
 
-    source_indices = set(range(len(stages))) - downstream_indices
+    source_hashes = set(hashed_stages.keys()) - downstream_hashes
 
     # Connect downstream stages with upstream stages via dependency field
-    pending = list(source_indices)
+    pending = list(source_hashes)
 
     while len(pending) > 0:
-        stage_index = pending.pop(0)
-        stage = stages[stage_index]
+        stage_hash = pending.pop(0)
+        stage = hashed_stages[stage_hash]
 
-        if "downstream-index" in stage:
-            downstream = stages[stage["downstream-index"]]
+        if "downstream-hash" in stage:
+            downstream = hashed_stages[stage["downstream-hash"]]
 
             # Connect this stage with the downstream stage
             if not "dependencies" in downstream:
                 downstream["dependencies"] = [None] * stage["downstream-length"]
 
-            downstream["dependencies"][stage["downstream-position"]] = stage_index
+            downstream["dependencies"][stage["downstream-position"]] = stage_hash
 
-            pending.append(stage["downstream-index"])
+            pending.append(stage["downstream-hash"])
 
     # Update configuration requirements based dependencies
-    pending = list(source_indices)
+    pending = list(source_hashes)
 
     while len(pending) > 0:
-        stage_index = pending.pop(0)
-        stage = stages[stage_index]
+        stage_hash = pending.pop(0)
+        stage = hashed_stages[stage_hash]
 
         if "dependencies" in stage:
             passed_config_options = {}
 
-            for upstream_index in stage["dependencies"]:
-                upstream = stages[upstream_index]
+            for upstream_hash in stage["dependencies"]:
+                upstream = hashed_stages[upstream_hash]
                 explicit_config_keys = upstream["downstream-passed-parameters"] if "downstream-passed-parameters" in upstream else set()
 
                 for key in upstream["config"].keys() - explicit_config_keys:
@@ -532,12 +537,13 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
                 else:
                     stage["config"][key] = value
 
-        if "downstream-index" in stage:
-            pending.append(stage["downstream-index"])
+        if "downstream-hash" in stage:
+            pending.append(stage["downstream-hash"])
 
     # Hash all stages
     required_hashes = {}
 
+    stages = hashed_stages.values()
     for stage in stages:
         stage["hash"] = hash_name(stage["wrapper"].name, stage["config"], stage["volatile_config"])
 
@@ -560,7 +566,7 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
         registry[stage["hash"]] = stage
 
         stage["dependencies"] = [
-            stages[index]["hash"] for index in stage["dependencies"]
+            hashed_stages[identification]["hash"] for identification in stage["dependencies"]
         ] if "dependencies" in stage else []
 
     for hash in required_hashes:

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -449,7 +449,7 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
 
         # Identification
         config.update(required_config)
-        identification_hash = hash_name(definition["wrapper"].name, config, {})
+        identification_hash = hash_name(definition["wrapper"].name, config, {}) + (str(definition["ephemeral"]) if "ephemeral" in definition else "")
 
         while identification_hash in hashed_stages:
             identification_hash = "{}+".format(identification_hash)
@@ -471,10 +471,12 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
             upstream = copy.copy(upstream)
             upstream.update({
                 "config": upstream_config,
-                "downstream-hash": identification_hash,
-                "downstream-position": position,
-                "downstream-length": len(context.required_stages),
-                "downstream-passed-parameters": passed_parameters,
+                "downstream": [
+                    { 
+                        "hash": identification_hash, "position": position,
+                        "length": len(context.required_stages), "passed-parameters": passed_parameters 
+                    }
+                ],
                 "cycle_hashes": cycle_hashes,
                 "ephemeral": context.ephemeral_mask[position] or ("ephemeral" in definition and definition["ephemeral"])
             })
@@ -495,16 +497,17 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
         stage_hash = pending.pop(0)
         stage = hashed_stages[stage_hash]
 
-        if "downstream-hash" in stage:
-            downstream = hashed_stages[stage["downstream-hash"]]
+        if "downstream" in stage:
+            downstream_info = stage["downstream"][0]
+            downstream = hashed_stages[downstream_info["hash"]]
 
             # Connect this stage with the downstream stage
             if not "dependencies" in downstream:
-                downstream["dependencies"] = [None] * stage["downstream-length"]
+                downstream["dependencies"] = [None] * downstream_info["length"]
 
-            downstream["dependencies"][stage["downstream-position"]] = stage_hash
+            downstream["dependencies"][downstream_info["position"]] = stage_hash
 
-            pending.append(stage["downstream-hash"])
+            pending.append(downstream_info["hash"])
 
     # Update configuration requirements based dependencies
     pending = list(source_hashes)
@@ -518,7 +521,7 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
 
             for upstream_hash in stage["dependencies"]:
                 upstream = hashed_stages[upstream_hash]
-                explicit_config_keys = upstream["downstream-passed-parameters"] if "downstream-passed-parameters" in upstream else set()
+                explicit_config_keys = upstream["downstream"][0]["passed-parameters"] if "downstream" in upstream else set()
 
                 for key in upstream["config"].keys() - explicit_config_keys:
                     if key in upstream["volatile_config"]:
@@ -537,8 +540,8 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
                 else:
                     stage["config"][key] = value
 
-        if "downstream-hash" in stage:
-            pending.append(stage["downstream-hash"])
+        if "downstream" in stage:
+            pending.append(stage["downstream"][0]["hash"])
 
     # Hash all stages
     required_hashes = {}

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -403,6 +403,16 @@ class ExecuteContext(Context):
 
         return self.dependencies[self.required_stages.index(definition)]
 
+def calculate_identification_hash(wrapper, definition):
+    identification_hash = hashlib.md5()
+
+    identification_hash.update(json.dumps({
+        "name": wrapper.name,
+        "config": definition["config"] if "config" in definition else "",
+        "ephemeral": definition["ephemeral"] if "ephemeral" in definition else "unknown"
+    }, sort_keys = True).encode("utf-8"))
+
+    return identification_hash.hexdigest()
 
 def process_stages(definitions, global_config, externals={}, aliases={}):
     pending = copy.copy(definitions)
@@ -420,6 +430,19 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
         wrapper = resolve_stage(definition["descriptor"], externals, aliases)
         if wrapper is None:
             raise PipelineError(f"{definition['descriptor']} is not a supported object for pipeline stage definition!")
+
+        # A stage that has the same descriptor and is called with the same config
+        # must produce the same logic in the configure method and in execution. We
+        # hence do not examine the same case twice ...
+        identification_hash = calculate_identification_hash(wrapper, definition)
+
+        if identification_hash in hashed_stages:
+            # ... but we need to take care of reconstructing the dependency structure
+
+            stage = hashed_stages[identification_hash]
+            stage["downstream"] += definition["downstream"]
+
+            continue
 
         # Call the configure method of the stage and obtain parameters
         config = copy.copy(global_config)
@@ -446,13 +469,6 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
 
         if "cycle_hashes" in definition and cycle_hash in definition["cycle_hashes"]:
             raise PipelineError("Found cycle in dependencies: %s" % definition["wrapper"].name)
-
-        # Identification
-        config.update(required_config)
-        identification_hash = hash_name(definition["wrapper"].name, config, {}) + (str(definition["ephemeral"]) if "ephemeral" in definition else "")
-
-        while identification_hash in hashed_stages:
-            identification_hash = "{}+".format(identification_hash)
 
         # Everything fine, add 
         hashed_stages[identification_hash] = definition
@@ -483,10 +499,12 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
             pending.append(upstream)
 
     # Now go backwards in the tree to find intermediate config requirements and set up dependencies
-    downstream_hashes = set([
-        stage["downstream-hash"]
-        for stage in hashed_stages.values() if "downstream-hash" in stage
-    ])
+    downstream_hashes = set()
+    
+    for stage in hashed_stages.values():
+        if "downstream" in stage:
+            for info in stage["downstream"]:
+                downstream_hashes.add(info["hash"])
 
     source_hashes = set(hashed_stages.keys()) - downstream_hashes
 
@@ -498,16 +516,16 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
         stage = hashed_stages[stage_hash]
 
         if "downstream" in stage:
-            downstream_info = stage["downstream"][0]
-            downstream = hashed_stages[downstream_info["hash"]]
+            for downstream_info in stage["downstream"]:
+                downstream = hashed_stages[downstream_info["hash"]]
 
-            # Connect this stage with the downstream stage
-            if not "dependencies" in downstream:
-                downstream["dependencies"] = [None] * downstream_info["length"]
+                # Connect this stage with the downstream stage
+                if not "dependencies" in downstream:
+                    downstream["dependencies"] = [None] * downstream_info["length"]
 
-            downstream["dependencies"][downstream_info["position"]] = stage_hash
+                downstream["dependencies"][downstream_info["position"]] = stage_hash
 
-            pending.append(downstream_info["hash"])
+                pending.append(downstream_info["hash"])
 
     # Update configuration requirements based dependencies
     pending = list(source_hashes)
@@ -521,7 +539,12 @@ def process_stages(definitions, global_config, externals={}, aliases={}):
 
             for upstream_hash in stage["dependencies"]:
                 upstream = hashed_stages[upstream_hash]
-                explicit_config_keys = upstream["downstream"][0]["passed-parameters"] if "downstream" in upstream else set()
+                
+                explicit_config_keys = set()
+
+                if "downstream" in upstream:
+                    for info in upstream["downstream"]:
+                        explicit_config_keys |= info["passed-parameters"]
 
                 for key in upstream["config"].keys() - explicit_config_keys:
                     if key in upstream["volatile_config"]:

--- a/tests/test_run_stages.py
+++ b/tests/test_run_stages.py
@@ -65,7 +65,7 @@ def test_rerun_required(tmpdir):
 
 def test_wrapper(tmpdir):
     working_directory = tmpdir.mkdir("sub")
-    wrapper = synpp.Synpp(working_directory = working_directory, config = {})
+    wrapper = synpp.Synpp(config={'working_directory': working_directory})
     assert 14 == wrapper.run_single(descriptor="tests.fixtures.sum_config", config={"a": 5, "b": 9})
     res = wrapper.run_pipeline(definitions=[{"descriptor": "tests.fixtures.sum_config", "config": {"a": 5, "b": 9}}])
     assert len(res) == 1

--- a/tests/test_run_stages.py
+++ b/tests/test_run_stages.py
@@ -65,7 +65,7 @@ def test_rerun_required(tmpdir):
 
 def test_wrapper(tmpdir):
     working_directory = tmpdir.mkdir("sub")
-    wrapper = synpp.Synpp(config={'working_directory': working_directory})
+    wrapper = synpp.Synpp(working_directory = working_directory, config = {})
     assert 14 == wrapper.run_single(descriptor="tests.fixtures.sum_config", config={"a": 5, "b": 9})
     res = wrapper.run_pipeline(definitions=[{"descriptor": "tests.fixtures.sum_config", "config": {"a": 5, "b": 9}}])
     assert len(res) == 1

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,0 +1,92 @@
+import logging
+import random
+import time
+
+import synpp
+
+
+_GRAPH_CACHE = {}
+
+
+def _build_random_graph(seed, number_of_stages, max_parents):
+	rng = random.Random(seed)
+	graph = {}
+
+	for node_id in range(number_of_stages):
+		if node_id == 0:
+			graph[node_id] = []
+			continue
+
+		parent_count = rng.randint(0, min(max_parents, node_id))
+		parents = rng.sample(range(node_id), k=parent_count)
+		graph[node_id] = sorted(parents)
+
+	return graph
+
+
+def _get_graph(seed, number_of_stages):
+	key = (seed, number_of_stages)
+	if key not in _GRAPH_CACHE:
+		_GRAPH_CACHE[key] = _build_random_graph(seed, number_of_stages, max_parents=7)
+	return _GRAPH_CACHE[key]
+
+
+class RandomGraphStage:
+	def configure(self, context):
+		seed = context.config("speed.seed")
+		number_of_stages = context.config("speed.number_of_stages")
+		node_id = context.config("speed.node_id")
+
+		graph = _get_graph(seed, number_of_stages)
+		for parent_id in graph[node_id]:
+			context.stage(RandomGraphStage, config={
+				"speed.seed": seed,
+				"speed.number_of_stages": number_of_stages,
+				"speed.node_id": parent_id,
+			})
+
+	def execute(self, context):
+		# Do nothing
+		return None
+
+
+def run_random_graph_pipeline(seed, number_of_stages):
+	_get_graph(seed, number_of_stages)
+
+	definitions = [{
+		"descriptor": RandomGraphStage,
+		"config": {
+			"speed.seed": seed,
+			"speed.number_of_stages": number_of_stages,
+			"speed.node_id": node_id,
+		},
+	} for node_id in range(number_of_stages)]
+
+	started_at = time.perf_counter()
+	synpp.run(definitions, config={
+			"speed.seed": seed,
+			"speed.number_of_stages": number_of_stages,}, working_directory=None)
+	return time.perf_counter() - started_at
+
+
+def test_speed_random_graph_runs_and_logs():
+	logger = logging.getLogger("tests.speed")
+
+	elapsed_10 = run_random_graph_pipeline(seed=1997, number_of_stages=10)
+	logger.info("Speed test | stages=10 | elapsed=%.3fs", elapsed_10)
+	print("Speed test | stages=10 | elapsed=%.3fs" % elapsed_10)
+	
+	elapsed_20 = run_random_graph_pipeline(seed=1997, number_of_stages=20)
+	logger.info("Speed test | stages=20 | elapsed=%.3fs", elapsed_20)
+	print("Speed test | stages=20 | elapsed=%.3fs" % elapsed_20)
+
+	elapsed_50 = run_random_graph_pipeline(seed=1997, number_of_stages=50)
+	logger.info("Speed test | stages=50 | elapsed=%.3fs", elapsed_50)
+	print("Speed test | stages=50 | elapsed=%.3fs" % elapsed_50)
+	
+	#elapsed_200 = run_random_graph_pipeline(seed=1997, number_of_stages=200)
+	#logger.info("Speed test | stages=200 | elapsed=%.3fs", elapsed_200)
+	#print("Speed test | stages=200 | elapsed=%.3fs" % elapsed_200)
+
+	assert elapsed_10 >= 0.0
+	assert elapsed_50 >= 0.0


### PR DESCRIPTION
- Switch from an index-based resolution of the dependency tree to a hash-based one. The main idea is that a stage that is configured with the same stage descriptor (code) and stage config (passed from downstream) will always provide the same behaviour.
- This is then exploited by making sure that the same stage (same hash) is never evaluated twice.

Simpler fix than #93.