### PR TITLE
feat: cleaner command line configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,13 +444,17 @@ To define the list of stages to run, provide individual `--run` options. They wi
 --run stage1 --run stage2
 ```
 
-To override configruation, options, prepend them with two dashes:
+To override configuration options, provide the key and value either using `--config` or `-c`:
 
 ``bash
---my.config.option value
+--config my.config.option value
 ``
 
-If a value is already present in the config file, the provided value will automatically be cast to the same data type. If the value does not exist yet, any argument is treated as a string.
+If a value is already present in the config file, the provided value will automatically be cast to the same data type. If the value does not exist yet, any argument is treated as a string by default. If you want to specifically set the value as `int` or `float`, use the following pattern:
+
+``bash
+--config:int my.config.option 55
+``
 
 ## NYC Taxi Example
 

--- a/src/synpp/pipeline.py
+++ b/src/synpp/pipeline.py
@@ -939,11 +939,36 @@ def run_from_cmd(argv):
         elif argv[k] == "--run":
             run.add(argv[k + 1])
             k += 2
-        elif argv[k].startswith("--"):
-            option = argv[k][2:]
-            value = argv[k + 1]
+        elif argv[k].startswith("--config") or argv[k].startswith("-c"):
+            remainder = ""
+
+            if argv[k].startswith("--config"):
+                remainder = argv[k].replace("--config", "")
+
+            if argv[k].startswith("-c"):
+                remainder = argv[k].replace("-c", "")
+
+            converter = str
+            if len(remainder) > 0:
+                assert remainder[0] == ":", "Expected type info for config entry"
+                remainder = remainder[1:]
+
+                if remainder == "int":
+                    converter = int
+                elif remainder == "float":
+                    converter = float
+                elif remainder == "json":
+                    converter = json.loads
+                else:
+                    raise RuntimeError("Unknown converter: ".format(remainder))
+
+            if not (k + 2 < len(argv)):
+                raise RuntimeError("Expected a config key and a value")
+
+            option = argv[k + 1]
+            value = converter(argv[k + 2])
             overrides[option] = value
-            k += 2
+            k += 3
         else:
             if config_path is not None:
                 raise RuntimeError("Config path already provided")


### PR DESCRIPTION
You must now use the cleaner `--config my_option 55` or `-c my_option 55` and you can even specify the type:  `-c:int my_option 55` instead of the previous `--my_option 55`.